### PR TITLE
Add minimal Command Central skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "dtos",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"No tests implemented\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/src/app/app.component.js
+++ b/src/app/app.component.js
@@ -1,0 +1,60 @@
+import { TasksComponent } from './tasks/tasks.component.js';
+import { LogbookComponent } from './logbook/logbook.component.js';
+import { QuickNotesComponent } from './quicknotes/quicknotes.component.js';
+import { VaultComponent } from './vault/vault.component.js';
+import { SettingsComponent } from './settings/settings.component.js';
+
+export class AppComponent {
+  constructor(root) {
+    this.root = root;
+    this.current = null;
+    this.render();
+  }
+
+  render() {
+    this.root.innerHTML = `
+      <nav class="tabs">
+        <button id="tasks-tab" class="active">Tasks</button>
+        <button id="logbook-tab">Logbook</button>
+        <button id="notes-tab">Notes</button>
+        <button id="vault-tab">Vault</button>
+        <button id="settings-tab">Settings</button>
+      </nav>
+      <div id="content"></div>
+    `;
+    this.content = document.getElementById('content');
+    this.bindNav();
+    this.show('tasks');
+  }
+
+  bindNav() {
+    this.root.querySelector('#tasks-tab').addEventListener('click', () => this.show('tasks'));
+    this.root.querySelector('#logbook-tab').addEventListener('click', () => this.show('logbook'));
+    this.root.querySelector('#notes-tab').addEventListener('click', () => this.show('notes'));
+    this.root.querySelector('#vault-tab').addEventListener('click', () => this.show('vault'));
+    this.root.querySelector('#settings-tab').addEventListener('click', () => this.show('settings'));
+  }
+
+  show(tab) {
+    this.root.querySelectorAll('nav button').forEach(btn => btn.classList.remove('active'));
+    this.root.querySelector(`#${tab}-tab`).classList.add('active');
+    this.content.innerHTML = '';
+    switch(tab) {
+      case 'tasks':
+        this.current = new TasksComponent(this.content);
+        break;
+      case 'logbook':
+        this.current = new LogbookComponent(this.content);
+        break;
+      case 'notes':
+        this.current = new QuickNotesComponent(this.content);
+        break;
+      case 'vault':
+        this.current = new VaultComponent(this.content);
+        break;
+      case 'settings':
+        this.current = new SettingsComponent(this.content);
+        break;
+    }
+  }
+}

--- a/src/app/logbook/logbook.component.js
+++ b/src/app/logbook/logbook.component.js
@@ -1,0 +1,21 @@
+export class LogbookComponent {
+  constructor(root) {
+    this.root = root;
+    this.entries = [];
+    this.render();
+  }
+
+  addEntry(text) {
+    this.entries.push({ text, date: new Date() });
+    this.render();
+  }
+
+  render() {
+    this.root.innerHTML = `
+      <h2>Logbook</h2>
+      <ul>
+        ${this.entries.map(e => `<li>${e.date.toLocaleString()}: ${e.text}</li>`).join('')}
+      </ul>
+    `;
+  }
+}

--- a/src/app/quicknotes/quicknotes.component.js
+++ b/src/app/quicknotes/quicknotes.component.js
@@ -1,0 +1,36 @@
+export class QuickNotesComponent {
+  constructor(root) {
+    this.root = root;
+    this.notes = [];
+    this.render();
+  }
+
+  addNote(title, content) {
+    this.notes.push({ title, content });
+    this.render();
+  }
+
+  render() {
+    this.root.innerHTML = `
+      <h2>QuickNotes</h2>
+      <form id="note-form">
+        <input type="text" id="note-title" placeholder="Title" required />
+        <textarea id="note-content" placeholder="Note" required></textarea>
+        <button type="submit">Add</button>
+      </form>
+      <ul id="note-list"></ul>
+    `;
+    const form = this.root.querySelector('#note-form');
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const title = form.querySelector('#note-title').value;
+      const content = form.querySelector('#note-content').value;
+      this.addNote(title, content);
+      form.reset();
+    });
+    const list = this.root.querySelector('#note-list');
+    list.innerHTML = this.notes
+      .map(n => `<li><strong>${n.title}</strong><p>${n.content}</p></li>`)
+      .join('');
+  }
+}

--- a/src/app/settings/settings.component.js
+++ b/src/app/settings/settings.component.js
@@ -1,0 +1,19 @@
+export class SettingsComponent {
+  constructor(root) {
+    this.root = root;
+    this.dark = false;
+    this.render();
+  }
+
+  render() {
+    this.root.innerHTML = `
+      <h2>Settings</h2>
+      <button id="theme-toggle">Toggle Theme</button>
+    `;
+    this.root.querySelector('#theme-toggle').addEventListener('click', () => {
+      this.dark = !this.dark;
+      document.body.style.background = this.dark ? '#333' : '#f5f5f5';
+      document.body.style.color = this.dark ? '#fff' : '#333';
+    });
+  }
+}

--- a/src/app/tasks/tasks.component.js
+++ b/src/app/tasks/tasks.component.js
@@ -1,0 +1,54 @@
+export class TasksComponent {
+  constructor(root) {
+    this.root = root;
+    this.tasks = [];
+    this.render();
+  }
+
+  addTask(title) {
+    this.tasks.push({ title, completed: false });
+    this.render();
+  }
+
+  toggleTask(index) {
+    this.tasks[index].completed = !this.tasks[index].completed;
+    this.render();
+  }
+
+  deleteTask(index) {
+    this.tasks.splice(index, 1);
+    this.render();
+  }
+
+  render() {
+    this.root.innerHTML = `
+      <h2>Command Tasks</h2>
+      <form id="task-form">
+        <input type="text" id="task-title" placeholder="New task" required />
+        <button type="submit">Add</button>
+      </form>
+      <ul id="task-list"></ul>
+    `;
+    const form = this.root.querySelector('#task-form');
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const input = form.querySelector('#task-title');
+      this.addTask(input.value);
+      input.value = '';
+    });
+    const list = this.root.querySelector('#task-list');
+    list.innerHTML = this.tasks
+      .map((t, i) => `<li>${t.completed ? '✅' : ''} ${t.title}
+        <button data-t="toggle" data-i="${i}">Toggle</button>
+        <button data-t="delete" data-i="${i}">Delete</button></li>`)
+      .join('');
+    list.querySelectorAll('button').forEach(btn => {
+      const i = parseInt(btn.dataset.i, 10);
+      if (btn.dataset.t === 'toggle') {
+        btn.addEventListener('click', () => this.toggleTask(i));
+      } else {
+        btn.addEventListener('click', () => this.deleteTask(i));
+      }
+    });
+  }
+}

--- a/src/app/vault/vault.component.js
+++ b/src/app/vault/vault.component.js
@@ -1,0 +1,51 @@
+export class VaultComponent {
+  constructor(root) {
+    this.root = root;
+    this.unlocked = false;
+    this.passwords = [];
+    this.render();
+  }
+
+  render() {
+    if (!this.unlocked) {
+      this.root.innerHTML = `
+        <h2>Vault</h2>
+        <form id="unlock-form">
+          <input type="password" id="master" placeholder="Master password" required />
+          <button type="submit">Unlock</button>
+        </form>
+      `;
+      this.root.querySelector('#unlock-form').addEventListener('submit', e => {
+        e.preventDefault();
+        this.unlocked = true; // placeholder
+        this.render();
+      });
+    } else {
+      this.root.innerHTML = `
+        <h2>Vault</h2>
+        <button id="lock">Lock</button>
+        <ul id="pw-list"></ul>
+        <form id="pw-form">
+          <input type="text" id="site" placeholder="Site" required />
+          <input type="text" id="pw" placeholder="Password" required />
+          <button type="submit">Add</button>
+        </form>
+      `;
+      this.root.querySelector('#lock').addEventListener('click', () => {
+        this.unlocked = false;
+        this.render();
+      });
+      this.root.querySelector('#pw-form').addEventListener('submit', e => {
+        e.preventDefault();
+        const site = this.root.querySelector('#site').value;
+        const pw = this.root.querySelector('#pw').value;
+        this.passwords.push({ site, pw });
+        this.render();
+      });
+      const list = this.root.querySelector('#pw-list');
+      list.innerHTML = this.passwords
+        .map(p => `<li>${p.site}: ${p.pw}</li>`)
+        .join('');
+    }
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Command Central</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <app-root>Loading...</app-root>
+  <script type="module" src="main.ts"></script>
+</body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,8 @@
+import { AppComponent } from './app/app.component.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.querySelector('app-root');
+  if (root) {
+    new AppComponent(root as HTMLElement);
+  }
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,28 @@
+body {
+  font-family: "Inter", sans-serif;
+  margin: 0;
+  padding: 0;
+  background: #f5f5f5;
+  color: #333;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(255,255,255,0.6);
+  backdrop-filter: blur(10px);
+}
+
+button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background: #e0e0e0;
+  cursor: pointer;
+}
+
+button.active {
+  background: #1976d2;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- initialize `package.json` with empty test
- add minimal skeleton for Command Central
  - `index.html`, `main.ts`, and global styles
  - simple tab-based navigation in `app.component.js`
  - stub components for tasks, logbook, quicknotes, vault, and settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685483e10f6c8331a069788b28a2478e